### PR TITLE
bach_size bug, here must be batch_size

### DIFF
--- a/tf_euler/python/run_loop.py
+++ b/tf_euler/python/run_loop.py
@@ -117,7 +117,7 @@ def run_train(model, flags_obj, master, is_chief):
       tf.train.LoggingTensorHook(
           tensor_to_log, every_n_iter=flags_obj.log_steps))
 
-  num_steps = int((flags_obj.max_id + 1) // flags_obj.batch_size *
+  num_steps = int((flags_obj.max_id + 1) // batch_size *
                    flags_obj.num_epochs)
   hooks.append(tf.train.StopAtStepHook(last_step=num_steps))
 


### PR DESCRIPTION
在第一个版本中，此处为batch_size而不是flags_obj.batch_size，第二个版本把此处改成了flags_obj.batch_size，个人认为是有错误的。个人理解，flags_obj.batch_size参数指的是实际的训练样本数量，而代码里头的batch_size是指每次抽样的节点数量，flags_obj.batch_size=batch_size*batch_size_ratio。此处num_steps应该继续使用第一个版本中的batch_size而不是flags_obj.batch_size。