### PR TITLE
fix CompactNode::GetTopKNeighbor(): min_heap.top() is compared with wrong weight

### DIFF
--- a/euler/core/compact_node.cc
+++ b/euler/core/compact_node.cc
@@ -191,14 +191,13 @@ CompactNode::GetTopKNeighbor(const std::vector<int32_t>& edge_types,
                           neighbor_groups_idx_[edge_type - 1];
       for (int32_t j = begin_idx; j <
            neighbor_groups_idx_[edge_type]; ++j) {
+        float pre = j == 0 ? 0 : neighbors_weight_[j - 1];
         if (static_cast<int32_t>(min_heap.size()) < k) {
-          float pre = j == 0 ? 0 : neighbors_weight_[j - 1];
           min_heap.push(euler::common::IDWeightPair(neighbors_[j],
                                                     neighbors_weight_[j] - pre,
                                                     edge_type));
         } else {
-          if (std::get<1>(min_heap.top()) < neighbors_weight_[j]) {
-            float pre = j == 0 ? 0 : neighbors_weight_[j - 1];
+          if (std::get<1>(min_heap.top()) < neighbors_weight_[j] - pre) {
             min_heap.pop();
             min_heap.push(euler::common::IDWeightPair(neighbors_[j],
                                                       neighbors_weight_[j] - pre,


### PR DESCRIPTION
In compact_node.cc, line 200, CompactNode::GetTopKNeighbor() :

If we need to update min_heap.top(), we should compare
'std::get<1>(min_heap.top())' with 'neighbors_weight_[j] - pre', instead of 'neighbors_weight_[j]'
